### PR TITLE
ci: add NEXT_PUBLIC_GENERAL_REQUEST_URL secret to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -85,6 +85,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+          build-args: |
+            NEXT_PUBLIC_GENERAL_REQUEST_URL=${{ secrets.NEXT_PUBLIC_GENERAL_REQUEST_URL }}
 
           # To improve build speeds, for each branch we push an additional image to the registry,
           # to be used as the caching layer, using the `max` caching mode.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ FROM node:${NODE_VERSION}-alpine AS base
 # Set working directory for all build stages.
 WORKDIR /usr/src/app
 
+# ==== App specific variables
+ARG NEXT_PUBLIC_GENERAL_REQUEST_URL
+ENV NEXT_PUBLIC_GENERAL_REQUEST_URL=${NEXT_PUBLIC_GENERAL_REQUEST_URL}
+
 # Configuración de PNPM
-
-
 # Install pnpm.
 # Install corepack and set pnpm as default package manager
 ENV PNPM_HOME="/pnpm"


### PR DESCRIPTION
✨ Cambios incluidos:
ci: agregar el secret NEXT_PUBLIC_GENERAL_REQUEST_URL en los workflows de GitHub Actions.
build: actualizar el Dockerfile para incluir la variable NEXT_PUBLIC_GENERAL_REQUEST_URL como variable de entorno.